### PR TITLE
Enable draw cross instead of circle in data point

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/data/LineDataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/data/LineDataSet.java
@@ -64,6 +64,11 @@ public class LineDataSet extends LineRadarDataSet<Entry> implements ILineDataSet
 
     private boolean mDrawCircleHole = true;
 
+    /**
+     * if true, drawing crosses is disabled by default
+     */
+    private boolean mDrawCross = false;
+
 
     public LineDataSet(List<Entry> yVals, String label) {
         super(yVals, label);
@@ -387,6 +392,20 @@ public class LineDataSet extends LineRadarDataSet<Entry> implements ILineDataSet
     @Override
     public boolean isDrawCircleHoleEnabled() {
         return mDrawCircleHole;
+    }
+
+    /**
+     * Set this to true to allow drawing a cross in each data position.
+     *
+     * @param enabled
+     */
+    public void setDrawCross(boolean enabled) {
+        mDrawCross = enabled;
+    }
+
+    @Override
+    public boolean isDrawCrossEnabled() {
+        return mDrawCross;
     }
 
     /**

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/interfaces/datasets/ILineDataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/interfaces/datasets/ILineDataSet.java
@@ -80,6 +80,13 @@ public interface ILineDataSet extends ILineRadarDataSet<Entry> {
     boolean isDrawCircleHoleEnabled();
 
     /**
+     * Returns true if drawing the cross is enabled, false if not.
+     *
+     * @return
+     */
+    boolean isDrawCrossEnabled();
+
+    /**
      * Returns the DashPathEffect that is used for drawing the lines.
      *
      * @return

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -7,6 +7,8 @@ import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.drawable.Drawable;
 
+import androidx.annotation.ColorInt;
+
 import com.github.mikephil.charting.animation.ChartAnimator;
 import com.github.mikephil.charting.charts.LineChart;
 import com.github.mikephil.charting.data.Entry;
@@ -652,11 +654,12 @@ public class LineChartRenderer extends LineRadarRenderer {
 
             float circleRadius = dataSet.getCircleRadius();
             float circleHoleRadius = dataSet.getCircleHoleRadius();
+            boolean drawCross = dataSet.isDrawCrossEnabled();
             boolean drawCircleHole = dataSet.isDrawCircleHoleEnabled() &&
-                    circleHoleRadius < circleRadius &&
-                    circleHoleRadius > 0.f;
+                circleHoleRadius < circleRadius &&
+                circleHoleRadius > 0.f && !drawCross;
             boolean drawTransparentCircleHole = drawCircleHole &&
-                    dataSet.getCircleHoleColor() == ColorTemplate.COLOR_NONE;
+                dataSet.getCircleHoleColor() == ColorTemplate.COLOR_NONE && !drawCross;
 
             DataSetImageCache imageCache;
 
@@ -671,7 +674,7 @@ public class LineChartRenderer extends LineRadarRenderer {
 
             // only fill the cache with new bitmaps if a change is required
             if (changeRequired) {
-                imageCache.fill(dataSet, drawCircleHole, drawTransparentCircleHole);
+                imageCache.fill(dataSet, drawCircleHole, drawTransparentCircleHole, drawCross);
             }
 
             int boundsRangeCount = mXBounds.range + mXBounds.min;
@@ -803,8 +806,9 @@ public class LineChartRenderer extends LineRadarRenderer {
          * @param set
          * @param drawCircleHole
          * @param drawTransparentCircleHole
+         * @param drawCross
          */
-        protected void fill(ILineDataSet set, boolean drawCircleHole, boolean drawTransparentCircleHole) {
+        protected void fill(ILineDataSet set, boolean drawCircleHole, boolean drawTransparentCircleHole, boolean drawCross) {
 
             int colorCount = set.getCircleColorCount();
             float circleRadius = set.getCircleRadius();
@@ -819,7 +823,11 @@ public class LineChartRenderer extends LineRadarRenderer {
                 circleBitmaps[i] = circleBitmap;
                 mRenderPaint.setColor(set.getCircleColor(i));
 
-                if (drawTransparentCircleHole) {
+                if (drawCross) {
+
+                    drawCrossInCanvas(canvas, circleRadius * 2.1f, set.getCircleColor(i));
+
+                } else if (drawTransparentCircleHole) {
                     // Begin path for circle with hole
                     mCirclePathBuffer.reset();
 
@@ -855,6 +863,21 @@ public class LineChartRenderer extends LineRadarRenderer {
                     }
                 }
             }
+        }
+
+        /**
+         * Draw a cross in the canvas with the size and color provided
+         *
+         * @param canvas
+         * @param size
+         * @param color
+         */
+        private void drawCrossInCanvas(Canvas canvas, float size, @ColorInt int color) {
+            Paint paint = new Paint();
+            paint.setColor(color);
+            paint.setStrokeWidth(5f);
+            canvas.drawLine(0, 0, size, size, paint);
+            canvas.drawLine(size, 0, 0, size, paint);
         }
 
         /**


### PR DESCRIPTION
### :pushpin: References
https://futureworkshops.atlassian.net/browse/THA-11

### :tophat: What is the goal?
In order to do this feature, I should allow to draw crosses instead of circles in the library.

### How is it being implemented?
1. In the `LineChartRenderer` if the flag is selected draw the cross using canvas.
2. In the `LineDataSet` add the property to permit select the draw cross flag.
