### PR TITLE
Add extra padding between chart and legend on bottom horizontal mode

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/components/Legend.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/components/Legend.java
@@ -126,6 +126,11 @@ public class Legend extends ComponentBase {
     private float mYEntrySpace = 0f;
 
     /**
+     * Extra padding on the legend at bottom horizontal mode, default is 0
+     */
+    private float mExtraPadding = 0f;
+
+    /**
      * the space between the legend entries on a vertical axis, default 2f
      * private float mYEntrySpace = 2f; /** the space between the form and the
      * actual label/text
@@ -558,6 +563,25 @@ public class Legend extends ComponentBase {
         mStackSpace = space;
     }
 
+
+    /**
+     * sets the extra padding of the legend at bottom horizontal mode
+     *
+     * @param value
+     */
+    public void setExtraPadding(float value) {
+        mExtraPadding = value;
+    }
+
+    /**
+     * returns the extra padding of the legend at bottom horizontal mode
+     *
+     * @return
+     */
+    public float getExtraPadding() {
+        return mExtraPadding;
+    }
+
     /**
      * the total width of the legend (needed width space)
      */
@@ -809,7 +833,8 @@ public class Legend extends ComponentBase {
 
                 mNeededWidth = maxLineWidth;
                 mNeededHeight = labelLineHeight
-                        * (float) (mCalculatedLineSizes.size())
+                    + mExtraPadding
+                    * (float) (mCalculatedLineSizes.size())
                         + labelLineSpacing *
                         (float) (mCalculatedLineSizes.size() == 0
                                 ? 0

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LegendRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LegendRenderer.java
@@ -331,7 +331,8 @@ public class LegendRenderer extends Renderer {
                         break;
 
                     case BOTTOM:
-                        posY = mViewPortHandler.getChartHeight() - yoffset - mLegend.mNeededHeight;
+                        posY = mViewPortHandler.getChartHeight() - yoffset - mLegend.mNeededHeight
+                            + mLegend.getExtraPadding();
                         break;
 
                     case CENTER:


### PR DESCRIPTION
### :pushpin: References
https://futureworkshops.atlassian.net/browse/THA-11

### :tophat: What is the goal?
Add more padding between the chart and the legend on the bottom horizontal mode.

### How is it being implemented?
1. In the `Legend` file add the extra padding property.
2. In the `LegendRenderer` add the extra padding when the legend is draw.